### PR TITLE
✨ 기능: 예외 처리 기능을 추가한다.

### DIFF
--- a/src/main/java/com/hangongsu/matching/global/exception/HangongsuException.java
+++ b/src/main/java/com/hangongsu/matching/global/exception/HangongsuException.java
@@ -9,4 +9,8 @@ public class HangongsuException extends RuntimeException {
         super(errorCode.getMessage());
         this.errorCode = errorCode;
     }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
 }

--- a/src/main/java/com/hangongsu/matching/global/exception/HangongsuException.java
+++ b/src/main/java/com/hangongsu/matching/global/exception/HangongsuException.java
@@ -1,0 +1,10 @@
+package com.hangongsu.matching.global.exception;
+
+public class HangongsuException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public HangongsuException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/hangongsu/matching/global/exception/HangongsuException.java
+++ b/src/main/java/com/hangongsu/matching/global/exception/HangongsuException.java
@@ -1,5 +1,7 @@
 package com.hangongsu.matching.global.exception;
 
+import com.hangongsu.matching.global.exception.code.ErrorCode;
+
 public class HangongsuException extends RuntimeException {
     private final ErrorCode errorCode;
 

--- a/src/main/java/com/hangongsu/matching/global/exception/advice/GlobalExceptionHandler.java
+++ b/src/main/java/com/hangongsu/matching/global/exception/advice/GlobalExceptionHandler.java
@@ -1,0 +1,24 @@
+package com.hangongsu.matching.global.exception.advice;
+
+import com.hangongsu.matching.global.exception.code.ErrorCode;
+import com.hangongsu.matching.global.exception.dto.response.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    private static final String LOG_FORMAT = "Class :: {} | Code :: {} | Message :: {}";
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
+        ErrorResponse response = ErrorResponse.of(errorCode);
+
+        log.error(LOG_FORMAT, e.getClass().getSimpleName(), errorCode.getCode(), errorCode.getMessage());
+
+        return ResponseEntity.status(errorCode.getStatus()).body(response);
+    }
+}

--- a/src/main/java/com/hangongsu/matching/global/exception/code/ErrorCode.java
+++ b/src/main/java/com/hangongsu/matching/global/exception/code/ErrorCode.java
@@ -1,0 +1,28 @@
+package com.hangongsu.matching.global.exception.code;
+
+public enum ErrorCode {
+    INTERNAL_SERVER_ERROR(500, "SV_001", "예상치 못한 서버 에러가 발생하였습니다.")
+
+    ;
+    private final int status;
+    private final String code;
+    private final String message;
+
+    ErrorCode(int status, String code, String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+
+    public int getStatus() {
+        return status;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/hangongsu/matching/global/exception/dto/response/ErrorResponse.java
+++ b/src/main/java/com/hangongsu/matching/global/exception/dto/response/ErrorResponse.java
@@ -1,0 +1,61 @@
+package com.hangongsu.matching.global.exception.dto.response;
+
+import com.hangongsu.matching.global.exception.code.ErrorCode;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.validation.BindingResult;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ErrorResponse {
+    private String message;
+    private List<FieldError> errors;
+    private String code;
+
+    private ErrorResponse(ErrorCode errorCode) {
+        this.message = errorCode.getMessage();
+        this.code = errorCode.getCode();
+        this.errors = new ArrayList<>();
+    }
+
+    private ErrorResponse(ErrorCode errorCode, BindingResult bindingResult) {
+        this.message = errorCode.getMessage();
+        this.errors = FieldError.of(bindingResult);
+        this.code = errorCode.getCode();
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode) {
+        return new ErrorResponse(errorCode);
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode, BindingResult bindingResult) {
+        return new ErrorResponse(errorCode, bindingResult);
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class FieldError {
+        private String field;
+        private String value;
+        private String reason;
+
+        private FieldError(String field, String value, String reason) {
+            this.field = field;
+            this.value = value;
+            this.reason = reason;
+        }
+
+        public static List<FieldError> of(BindingResult bindingResult) {
+            return bindingResult.getFieldErrors().stream()
+                    .map(error -> new FieldError(
+                            error.getField(),
+                            error.getRejectedValue() == null ? "" : error.getRejectedValue().toString(),
+                            error.getDefaultMessage()
+                    )).toList();
+        }
+    }
+}


### PR DESCRIPTION
## 연관 이슈
- closes #5 

## 작업
- [x] 전역 예외 처리를 위해 @RestControllerAdvice 어노테이션을 적용한 GlobalExceptionHandler를 정의했다.
- [x] 처리된 예외를 클라이언트에게 응답할 목적으로 ErrorResponse를 정의했다.
- [x] 에러의 상태값, 클라이언트와 소통할 코드, 에러 메세지를 담은 ErrorCode를 정의했다.
- [x] 추후 생겨날 예외 클래스가 모두 ErrorCode를 가지는 것을 유도하기 위해 RuntimeException을 상속한 상위 클래스 HangongsuException을 정의했다.

## 고민
- [x] ErrorResponse 필드 중 Validation 관련 에러에서 생겨나게 될 FieldError가 없을 때는 new ArrayList를 초기화하여 리턴하게 했는데, 더 좋은 방법이 없을까

## 학습
- [x] 다른 레포지토리를 참고하면서 패키지 구조나 예외 처리 방법의 다양성에 대해 배우게된 것 같다.